### PR TITLE
Support filtering reviews by rating

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,11 @@ We also select a filter to only show English language reviews.
 
 ### Usage
 
-`python get_reviews.py --book_ids_path your_file_path --output_directory_path your_directory_path --browser your_browser_name --sort_order your_sort_order  --format JSON (default) or CSV`
+`python get_reviews.py --book_ids_path your_file_path --output_directory_path your_directory_path --browser your_browser_name --sort_order your_sort_order --rating_filter your_rating_filter  --format JSON (default) or CSV`
 
 `sort_order` can be set to `default`,`newest` or `oldest`.
+
+`rating_filter` can be omitted or set to any number in the range 1-5.
 
 `browser` can be set to `chrome` or `firefox`. 
 
@@ -118,7 +120,7 @@ We also select a filter to only show English language reviews.
 
 ### Example
 
-`python get_reviews.py --book_ids_path most_popular_classics.txt --output_directory_path goodreads_project/classic_book_reviews --sort_order default --browser chrome`
+`python get_reviews.py --book_ids_path most_popular_classics.txt --output_directory_path goodreads_project/classic_book_reviews --sort_order default --rating_filter 5 --browser chrome`
 
 <br><br>
 


### PR DESCRIPTION
[Link to related issue](https://github.com/maria-antoniak/goodreads-scraper/issues/32)

This adds a new command argument (`--rating_filter`) to `get_reviews.py` to support filtering reviews by rating. 

This feature was motivated by the fact that Goodreads limits us to 300 results. If we filter by rating, we can access up to 5x as many reviews. 

I've tried to conform to the existing argument format style. If the argument is omitted, no filter will be applied and the scrape should return results identical as if this feature were not added. If the argument is provided, a file will be named according to the rating, e.g `1885.Pride_and_Prejudice_5_stars.json` instead of `1885.Pride_and_Prejudice.json`

